### PR TITLE
[Fix] UserSettings 폴더를 Git이 추적하지 않도록 .gitignore 경로 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /[Bb]uild/
 /[Bb]uilds/
 /[Ll]ogs/
-/[Uu]ser[Ss]ettings/
+VR_SONA/UserSettings/
 
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data


### PR DESCRIPTION
기존 .gitignore에는 /UserSettings/ 경로만 명시되어 있어 VR_SONA/UserSettings 폴더가 무시되지 않고 Git에 포함되는 문제가 있었음.
이를 해결하기 위해 .gitignore에서 경로를 VR_SONA/UserSettings/ 로 변경