### PR TITLE
[Feat] Additive 방식으로 미션 씬 로드 및 버튼/터레인 상태 제어 기능 추가

### DIFF
--- a/VR_SONA/Assets/Scenes/MissionBasketballScene.unity
+++ b/VR_SONA/Assets/Scenes/MissionBasketballScene.unity
@@ -2143,6 +2143,140 @@ RectTransform:
   m_AnchoredPosition: {x: -180, y: 16}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &851880652
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 851880653}
+  - component: {fileID: 851880655}
+  - component: {fileID: 851880654}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &851880653
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 851880652}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1147262718}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &851880654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 851880652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Back to Main Game
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &851880655
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 851880652}
+  m_CullTransparentMesh: 1
 --- !u!1001 &872485137
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2424,6 +2558,7 @@ RectTransform:
   - {fileID: 292437858}
   - {fileID: 6664562180453608330}
   - {fileID: 837010073}
+  - {fileID: 1147262718}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2852,6 +2987,156 @@ Rigidbody:
   m_Interpolate: 1
   m_Constraints: 126
   m_CollisionDetection: 1
+--- !u!1 &1147262717
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1147262718}
+  - component: {fileID: 1147262722}
+  - component: {fileID: 1147262721}
+  - component: {fileID: 1147262720}
+  - component: {fileID: 1147262719}
+  m_Layer: 5
+  m_Name: ReturnButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1147262718
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1147262717}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 851880653}
+  m_Father: {fileID: 920086284}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 403.8, y: 215.2}
+  m_SizeDelta: {x: 250, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1147262719
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1147262717}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f8e2672654014cc498a91aa274ace880, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  coinUIManager: {fileID: 0}
+  loadButton: {fileID: 0}
+  unloadButton: {fileID: 0}
+  returnButton: {fileID: 1147262717}
+--- !u!114 &1147262720
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1147262717}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1147262721}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1147262719}
+        m_TargetAssemblyTypeName: MissionSceneLoader, Assembly-CSharp
+        m_MethodName: ReturnToUI
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1147262721
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1147262717}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1147262722
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1147262717}
+  m_CullTransparentMesh: 1
 --- !u!1 &1148406076
 GameObject:
   m_ObjectHideFlags: 3

--- a/VR_SONA/Assets/Scenes/MissionBasketballScene.unity
+++ b/VR_SONA/Assets/Scenes/MissionBasketballScene.unity
@@ -2419,6 +2419,7 @@ MonoBehaviour:
   gameStateText: {fileID: 837010071}
   goalCount: 0
   requiredGoals: 1
+  returnButton: {fileID: 1147262717}
 --- !u!4 &878880130
 Transform:
   m_ObjectHideFlags: 0

--- a/VR_SONA/Assets/Scenes/UIScene.unity
+++ b/VR_SONA/Assets/Scenes/UIScene.unity
@@ -1285,6 +1285,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   buttonCanvas: {fileID: 902121342}
+  loadButton: {fileID: 788546955}
+  unloadButton: {fileID: 766329404}
 --- !u!1 &100240132 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4121915452331890060, guid: 36c69635d16b64e46a29ec445e299989, type: 3}
@@ -2589,6 +2591,26 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ab2d2dee9182bf249869d8b0bc5cdcc6, type: 3}
+--- !u!1 &232366680 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7171823405527562801, guid: a85a62d4ad966df4689be3b07e0e3c7d, type: 3}
+  m_PrefabInstance: {fileID: 1538532169}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &232366686
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 232366680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0d59f8186e539448bbf47179dbb47ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  buttonCanvas: {fileID: 902121342}
+  loadButton: {fileID: 788546955}
+  unloadButton: {fileID: 766329404}
 --- !u!4 &235017122 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8069669015559325251, guid: 27f81868b760cc64ebc1c4eba25c95c5, type: 3}
@@ -4749,6 +4771,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   buttonCanvas: {fileID: 902121342}
+  loadButton: {fileID: 788546955}
+  unloadButton: {fileID: 766329404}
 --- !u!1001 &436319115
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5616,6 +5640,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   buttonCanvas: {fileID: 902121342}
+  loadButton: {fileID: 788546955}
+  unloadButton: {fileID: 766329404}
 --- !u!1001 &510251733
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5848,6 +5874,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   coinUIManager: {fileID: 0}
+  loadButton: {fileID: 788546955}
+  unloadButton: {fileID: 766329404}
 --- !u!4 &523057121
 Transform:
   m_ObjectHideFlags: 0
@@ -9006,6 +9034,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   coinUIManager: {fileID: 63800757}
+  loadButton: {fileID: 788546955}
+  unloadButton: {fileID: 766329404}
 --- !u!1001 &791821913
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10558,6 +10588,7 @@ GameObject:
   - component: {fileID: 902121345}
   - component: {fileID: 902121344}
   - component: {fileID: 902121343}
+  - component: {fileID: 902121347}
   m_Layer: 5
   m_Name: ButtonCanvas
   m_TagString: Untagged
@@ -10649,6 +10680,18 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &902121347
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 902121342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29fb46b42b7c37b418c7795846d561ce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &903763703
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10875,8 +10918,16 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 190026710845066473, guid: 56ec1b96a6888444abeca665161c5ce9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -93.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 190026710845066473, guid: 56ec1b96a6888444abeca665161c5ce9, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 190026710845066473, guid: 56ec1b96a6888444abeca665161c5ce9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 57.4
       objectReference: {fileID: 0}
     - target: {fileID: 2609953844851659772, guid: 56ec1b96a6888444abeca665161c5ce9, type: 3}
       propertyPath: m_CullingMask.m_Bits
@@ -12822,6 +12873,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   buttonCanvas: {fileID: 902121342}
+  loadButton: {fileID: 788546955}
+  unloadButton: {fileID: 766329404}
 --- !u!4 &1095176479 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 9170577495445612818, guid: 67d3abe897c93a08e9593b0a183f2bb4, type: 3}
@@ -12960,6 +13013,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   buttonCanvas: {fileID: 902121342}
+  loadButton: {fileID: 788546955}
+  unloadButton: {fileID: 766329404}
 --- !u!1001 &1116869873
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17710,6 +17765,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   buttonCanvas: {fileID: 902121342}
+  loadButton: {fileID: 788546955}
+  unloadButton: {fileID: 766329404}
 --- !u!1 &1533240760
 GameObject:
   m_ObjectHideFlags: 0
@@ -18144,6 +18201,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 8739053859298823281, guid: a85a62d4ad966df4689be3b07e0e3c7d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1786995022}
+    - targetCorrespondingSourceObject: {fileID: 7171823405527562801, guid: a85a62d4ad966df4689be3b07e0e3c7d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 232366686}
     - targetCorrespondingSourceObject: {fileID: 204065838413963231, guid: a85a62d4ad966df4689be3b07e0e3c7d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1113880774}
@@ -20545,6 +20605,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   buttonCanvas: {fileID: 902121342}
+  loadButton: {fileID: 788546955}
+  unloadButton: {fileID: 766329404}
 --- !u!1001 &1790456702
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/VR_SONA/Assets/Scenes/UIScene.unity
+++ b/VR_SONA/Assets/Scenes/UIScene.unity
@@ -5877,6 +5877,7 @@ MonoBehaviour:
   loadButton: {fileID: 788546955}
   unloadButton: {fileID: 766329404}
   returnButton: {fileID: 0}
+  uiTerrain: {fileID: 1458396542}
 --- !u!4 &523057121
 Transform:
   m_ObjectHideFlags: 0
@@ -9038,6 +9039,7 @@ MonoBehaviour:
   loadButton: {fileID: 788546955}
   unloadButton: {fileID: 766329404}
   returnButton: {fileID: 0}
+  uiTerrain: {fileID: 0}
 --- !u!1001 &791821913
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10002,156 +10004,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 46710489}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &847744108
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 847744113}
-  - component: {fileID: 847744112}
-  - component: {fileID: 847744111}
-  - component: {fileID: 847744110}
-  - component: {fileID: 847744109}
-  m_Layer: 5
-  m_Name: ReturnButton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &847744109
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 847744108}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f8e2672654014cc498a91aa274ace880, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  coinUIManager: {fileID: 0}
-  loadButton: {fileID: 788546955}
-  unloadButton: {fileID: 766329404}
-  returnButton: {fileID: 847744108}
---- !u!114 &847744110
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 847744108}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 847744111}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 847744109}
-        m_TargetAssemblyTypeName: MissionSceneLoader, Assembly-CSharp
-        m_MethodName: ReturnToUI
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!114 &847744111
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 847744108}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &847744112
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 847744108}
-  m_CullTransparentMesh: 1
---- !u!224 &847744113
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 847744108}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1696199163}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 549.9991, y: 319.83493}
-  m_SizeDelta: {x: 160, y: 30}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &854105079
 GameObject:
   m_ObjectHideFlags: 0
@@ -17291,6 +17143,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8424503528261755352, guid: 01731519c681e5f45bc294844493d2b4, type: 3}
   m_PrefabInstance: {fileID: 1455365535}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1458396542 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7697992499408092261, guid: d0aed8937f333684ca9b34db06bd667f, type: 3}
+  m_PrefabInstance: {fileID: 1638884756}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1460248088
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -19965,140 +19822,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 01731519c681e5f45bc294844493d2b4, type: 3}
---- !u!1 &1696199162
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1696199163}
-  - component: {fileID: 1696199165}
-  - component: {fileID: 1696199164}
-  m_Layer: 5
-  m_Name: Text (TMP)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1696199163
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1696199162}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 847744113}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1696199164
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1696199162}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Back to Main Game
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &1696199165
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1696199162}
-  m_CullTransparentMesh: 1
 --- !u!4 &1704628074 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7051171039060373336, guid: 9412d4fe2a085084e814be20c0368aca, type: 3}
@@ -25836,4 +25559,3 @@ SceneRoots:
   - {fileID: 523057121}
   - {fileID: 902121346}
   - {fileID: 529990642}
-  - {fileID: 847744113}

--- a/VR_SONA/Assets/Scenes/UIScene.unity
+++ b/VR_SONA/Assets/Scenes/UIScene.unity
@@ -5876,6 +5876,7 @@ MonoBehaviour:
   coinUIManager: {fileID: 0}
   loadButton: {fileID: 788546955}
   unloadButton: {fileID: 766329404}
+  returnButton: {fileID: 0}
 --- !u!4 &523057121
 Transform:
   m_ObjectHideFlags: 0
@@ -9036,6 +9037,7 @@ MonoBehaviour:
   coinUIManager: {fileID: 63800757}
   loadButton: {fileID: 788546955}
   unloadButton: {fileID: 766329404}
+  returnButton: {fileID: 0}
 --- !u!1001 &791821913
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10000,6 +10002,156 @@ Transform:
   m_Children: []
   m_Father: {fileID: 46710489}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &847744108
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 847744113}
+  - component: {fileID: 847744112}
+  - component: {fileID: 847744111}
+  - component: {fileID: 847744110}
+  - component: {fileID: 847744109}
+  m_Layer: 5
+  m_Name: ReturnButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &847744109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 847744108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f8e2672654014cc498a91aa274ace880, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  coinUIManager: {fileID: 0}
+  loadButton: {fileID: 788546955}
+  unloadButton: {fileID: 766329404}
+  returnButton: {fileID: 847744108}
+--- !u!114 &847744110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 847744108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 847744111}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 847744109}
+        m_TargetAssemblyTypeName: MissionSceneLoader, Assembly-CSharp
+        m_MethodName: ReturnToUI
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &847744111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 847744108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &847744112
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 847744108}
+  m_CullTransparentMesh: 1
+--- !u!224 &847744113
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 847744108}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1696199163}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 549.9991, y: 319.83493}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &854105079
 GameObject:
   m_ObjectHideFlags: 0
@@ -19813,6 +19965,140 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 01731519c681e5f45bc294844493d2b4, type: 3}
+--- !u!1 &1696199162
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1696199163}
+  - component: {fileID: 1696199165}
+  - component: {fileID: 1696199164}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1696199163
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1696199162}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 847744113}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1696199164
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1696199162}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Back to Main Game
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1696199165
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1696199162}
+  m_CullTransparentMesh: 1
 --- !u!4 &1704628074 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7051171039060373336, guid: 9412d4fe2a085084e814be20c0368aca, type: 3}
@@ -25550,3 +25836,4 @@ SceneRoots:
   - {fileID: 523057121}
   - {fileID: 902121346}
   - {fileID: 529990642}
+  - {fileID: 847744113}

--- a/VR_SONA/Assets/Scripts/BasketBall/GameManager.cs
+++ b/VR_SONA/Assets/Scripts/BasketBall/GameManager.cs
@@ -17,9 +17,13 @@ public class GameManager : MonoBehaviour
 
     private bool isGameEnded = false;
 
+    public GameObject returnButton;
+
     private void Awake()
     {
         Instance = this;
+
+        if (returnButton != null) returnButton.SetActive(false);
     }
 
     public void AddGoal()
@@ -53,5 +57,7 @@ public class GameManager : MonoBehaviour
         }
 
         Time.timeScale = 0f;
+
+        if (returnButton != null) returnButton.SetActive(true);
     }
 }

--- a/VR_SONA/Assets/Scripts/UI/MissionSceneLoader.cs
+++ b/VR_SONA/Assets/Scripts/UI/MissionSceneLoader.cs
@@ -4,10 +4,11 @@ using UnityEngine.SceneManagement;
 public class MissionSceneLoader : MonoBehaviour
 {
     public CoinUIManager coinUIManager; // Inspector에서 연결할 예정
+    public GameObject loadButton;
+    public GameObject unloadButton;
 
     void Start()
     {
-        // 자동으로 CoinUIManager 찾기 (보조용)
         if (coinUIManager == null)
         {
             coinUIManager = FindObjectOfType<CoinUIManager>();
@@ -16,6 +17,15 @@ public class MissionSceneLoader : MonoBehaviour
                 Debug.LogError("CoinUIManager가 씬에 존재하지 않습니다!");
             }
         }
+
+        // 씬 상태 확인해서 버튼 조정
+        if (SceneManager.GetSceneByName("MissionBasketballScene").isLoaded)
+        {
+            // 미션 씬 올라와 있는 상태면 load/unload 숨기고 되돌아가기 버튼 표시
+            if (loadButton != null) loadButton.SetActive(false);
+            if (unloadButton != null) unloadButton.SetActive(false);
+        }
+
     }
 
     public void LoadMissionScene()
@@ -29,8 +39,21 @@ public class MissionSceneLoader : MonoBehaviour
         if (coinUIManager.HasEnoughCoins())
         {
             coinUIManager.SubtractCoinsForMission();
-            SceneManager.LoadScene("MissionBasketballScene", LoadSceneMode.Additive);
-            Debug.Log("미션 씬 로드 및 코인 차감 완료");
+
+            // 로드할 씬이 이미 로드되어 있지 않다면 추가
+            if (!SceneManager.GetSceneByName("MissionBasketballScene").isLoaded)
+            {
+                SceneManager.LoadScene("MissionBasketballScene", LoadSceneMode.Additive);
+                Debug.Log("미션 씬 로드 및 코인 차감 완료");
+
+                // Load/Unload 버튼 숨기고 Return 버튼 표시
+                if (loadButton != null) loadButton.SetActive(false);
+                if (unloadButton != null) unloadButton.SetActive(false);
+            }
+            else
+            {
+                Debug.Log("이미 미션 씬이 로드되어 있습니다.");
+            }
         }
         else
         {
@@ -40,6 +63,23 @@ public class MissionSceneLoader : MonoBehaviour
 
     public void UnloadMissionScene()
     {
-        SceneManager.UnloadSceneAsync("MissionBasketballScene");
+        // 버튼만 숨김
+        if (loadButton != null) loadButton.SetActive(false);
+        if (unloadButton != null) unloadButton.SetActive(false);
+    }
+
+    public void ReturnToUI()
+    {
+        // 되돌아가기: 미션 씬만 언로드
+        if (SceneManager.GetSceneByName("MissionBasketballScene").isLoaded)
+        {
+            SceneManager.UnloadSceneAsync("MissionBasketballScene");
+
+            // 다시 Load/Unload 버튼 표시
+            if (loadButton != null) loadButton.SetActive(true);
+            if (unloadButton != null) unloadButton.SetActive(true);
+
+            Debug.Log("미션 씬에서 UI 씬으로 돌아옴");
+        }
     }
 }

--- a/VR_SONA/Assets/Scripts/UI/MissionSceneLoader.cs
+++ b/VR_SONA/Assets/Scripts/UI/MissionSceneLoader.cs
@@ -6,6 +6,7 @@ public class MissionSceneLoader : MonoBehaviour
     public CoinUIManager coinUIManager; // Inspector에서 연결할 예정
     public GameObject loadButton;
     public GameObject unloadButton;
+    public GameObject returnButton; // 되돌아가기 버튼 (미션 씬에서만 표시)
 
     void Start()
     {
@@ -24,8 +25,12 @@ public class MissionSceneLoader : MonoBehaviour
             // 미션 씬 올라와 있는 상태면 load/unload 숨기고 되돌아가기 버튼 표시
             if (loadButton != null) loadButton.SetActive(false);
             if (unloadButton != null) unloadButton.SetActive(false);
+            if (returnButton != null) returnButton.SetActive(true);
         }
-
+        else
+        {
+            if (returnButton != null) returnButton.SetActive(false);
+        }
     }
 
     public void LoadMissionScene()
@@ -49,6 +54,7 @@ public class MissionSceneLoader : MonoBehaviour
                 // Load/Unload 버튼 숨기고 Return 버튼 표시
                 if (loadButton != null) loadButton.SetActive(false);
                 if (unloadButton != null) unloadButton.SetActive(false);
+                if (returnButton != null) returnButton.SetActive(true);
             }
             else
             {
@@ -78,6 +84,7 @@ public class MissionSceneLoader : MonoBehaviour
             // 다시 Load/Unload 버튼 표시
             if (loadButton != null) loadButton.SetActive(true);
             if (unloadButton != null) unloadButton.SetActive(true);
+            if (returnButton != null) returnButton.SetActive(false);
 
             Debug.Log("미션 씬에서 UI 씬으로 돌아옴");
         }

--- a/VR_SONA/Assets/Scripts/UI/MissionSceneLoader.cs
+++ b/VR_SONA/Assets/Scripts/UI/MissionSceneLoader.cs
@@ -7,6 +7,8 @@ public class MissionSceneLoader : MonoBehaviour
     public GameObject loadButton;
     public GameObject unloadButton;
     public GameObject returnButton; // 되돌아가기 버튼 (미션 씬에서만 표시)
+    
+    public GameObject uiTerrain;
 
     void Start()
     {
@@ -22,6 +24,8 @@ public class MissionSceneLoader : MonoBehaviour
         // 씬 상태 확인해서 버튼 조정
         if (SceneManager.GetSceneByName("MissionBasketballScene").isLoaded)
         {
+            if (uiTerrain != null) uiTerrain.SetActive(false); // ui씬의 terrain 비활성화
+
             // 미션 씬 올라와 있는 상태면 load/unload 숨기고 되돌아가기 버튼 표시
             if (loadButton != null) loadButton.SetActive(false);
             if (unloadButton != null) unloadButton.SetActive(false);
@@ -50,6 +54,8 @@ public class MissionSceneLoader : MonoBehaviour
             {
                 SceneManager.LoadScene("MissionBasketballScene", LoadSceneMode.Additive);
                 Debug.Log("미션 씬 로드 및 코인 차감 완료");
+
+                if (uiTerrain != null) uiTerrain.SetActive(false); // ui씬의 terrain 비활성화
 
                 // Load/Unload 버튼 숨기고 Return 버튼 표시
                 if (loadButton != null) loadButton.SetActive(false);
@@ -80,6 +86,7 @@ public class MissionSceneLoader : MonoBehaviour
         if (SceneManager.GetSceneByName("MissionBasketballScene").isLoaded)
         {
             SceneManager.UnloadSceneAsync("MissionBasketballScene");
+            if (uiTerrain != null) uiTerrain.SetActive(true); // ui씬의 terrain 활성화
 
             // 다시 Load/Unload 버튼 표시
             if (loadButton != null) loadButton.SetActive(true);

--- a/VR_SONA/Assets/Scripts/UI/ShowBasketButtonOnCameraEnter.cs
+++ b/VR_SONA/Assets/Scripts/UI/ShowBasketButtonOnCameraEnter.cs
@@ -3,18 +3,26 @@ using UnityEngine;
 public class ShowBasketButtonsOnCameraEnter : MonoBehaviour
 {
     public GameObject buttonCanvas;
+    public GameObject loadButton;
+    public GameObject unloadButton;
 
     void Start()
     {
-        buttonCanvas.SetActive(false); // 시작할 때 꺼두기
+        buttonCanvas.SetActive(false);
+        if (loadButton != null) loadButton.SetActive(false);
+        if (unloadButton != null) unloadButton.SetActive(false);
     }
 
     void OnTriggerEnter(Collider other)
     {
         if (other.CompareTag("MainCamera"))
         {
-            Debug.Log("Entered Tile2(7): " + other.name);
+            Debug.Log("Entered Tile: " + other.name);
             buttonCanvas.SetActive(true);
+
+            // 버튼들도 다시 켜줌
+            if (loadButton != null) loadButton.SetActive(true);
+            if (unloadButton != null) unloadButton.SetActive(true);
         }
     }
 
@@ -22,8 +30,11 @@ public class ShowBasketButtonsOnCameraEnter : MonoBehaviour
     {
         if (other.CompareTag("MainCamera"))
         {
-            Debug.Log("Exited Tile2(7): " + other.name);
+            Debug.Log("Exited Tile: " + other.name);
             buttonCanvas.SetActive(false);
+
+            if (loadButton != null) loadButton.SetActive(false);
+            if (unloadButton != null) unloadButton.SetActive(false);
         }
     }
 }


### PR DESCRIPTION
- 미션 씬 로드 후에만 Return 버튼이 활성화되도록 로직 수정
- 미션 씬을 로드하고 나면 Load/Unload 버튼을 숨기고 미션 종료 시에 Return 버튼을 표시
- 미션 씬 로드 시 UI 씬의 터레인 비활성화 및 미션 씬 종료 후 UI 씬으로 돌아갈 때 터레인 재활성화
